### PR TITLE
Migrated from createClass

### DIFF
--- a/lib/components/TrackedComponent.js
+++ b/lib/components/TrackedComponent.js
@@ -5,6 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.TrackedComponent = undefined;
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -17,29 +19,52 @@ var _away2 = _interopRequireDefault(_away);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var TrackedComponent = exports.TrackedComponent = _react2.default.createClass({
-  displayName: "TrackedComponent",
-  render: function render() {
-    return false;
-  },
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  componentWillMount: function componentWillMount() {
-    this.componentWillMountTimestamp = Date.now();
-    this.idleTimeInMs = 0;
-    var timer = (0, _away2.default)(30000);
-    var self = this;
-    timer.on('idle', function () {
-      self.startIdleTimer = Date.now();
-    });
-    timer.on('active', function () {
-      self.idleTimeInMs += Date.now() - self.startIdleTimer;
-    });
-  },
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  componentWillUnmount: function componentWillUnmount() {
-    if (!this.componentWillMountTimestamp) {
-      throw "ComponentWillMountTimestamp was not initialized. Check if super.componentWillMount() was called";
-    }
-    _applicationinsightsJs.AppInsights.trackMetric("React Component Engaged Time (seconds)", (Date.now() - this.componentWillMountTimestamp - (this.idleTimeInMs ? this.idleTimeInMs : 0)) / 1000, 1, null, null, { 'Component Name': this.constructor.displayName });
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var TrackedComponent = exports.TrackedComponent = function (_Component) {
+  _inherits(TrackedComponent, _Component);
+
+  function TrackedComponent() {
+    _classCallCheck(this, TrackedComponent);
+
+    var _this = _possibleConstructorReturn(this, (TrackedComponent.__proto__ || Object.getPrototypeOf(TrackedComponent)).call(this));
+
+    _this.displayName = "TrackedComponent";
+    return _this;
   }
-});
+
+  _createClass(TrackedComponent, [{
+    key: 'render',
+    value: function render() {
+      return false;
+    }
+  }, {
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      this.componentWillMountTimestamp = Date.now();
+      this.idleTimeInMs = 0;
+      var timer = (0, _away2.default)(30000);
+      var self = this;
+      timer.on('idle', function () {
+        self.startIdleTimer = Date.now();
+      });
+      timer.on('active', function () {
+        self.idleTimeInMs += Date.now() - self.startIdleTimer;
+      });
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (!this.componentWillMountTimestamp) {
+        throw "ComponentWillMountTimestamp was not initialized. Check if super.componentWillMount() was called";
+      }
+      _applicationinsightsJs.AppInsights.trackMetric("React Component Engaged Time (seconds)", (Date.now() - this.componentWillMountTimestamp - (this.idleTimeInMs ? this.idleTimeInMs : 0)) / 1000, 1, null, null, { 'Component Name': this.constructor.displayName });
+    }
+  }]);
+
+  return TrackedComponent;
+}(_react.Component);

--- a/src/components/TrackedComponent.js
+++ b/src/components/TrackedComponent.js
@@ -1,16 +1,20 @@
 'use strict';
 
-import React from 'react';
+import React, {Component} from 'react';
 import {AppInsights} from "applicationinsights-js"
 import away from 'away';
 
-export const TrackedComponent = React.createClass({
-  displayName: "TrackedComponent",
-  render: function render() {
-    return false;
-  },
+export class TrackedComponent extends Component {
+  constructor() {
+    super();
+    this.displayName = "TrackedComponent";
+  }
 
-  componentWillMount:function (){
+  render() {
+    return false;
+  }
+
+  componentWillMount(){
     this.componentWillMountTimestamp = Date.now();
     this.idleTimeInMs = 0;
     var timer = away(30000);
@@ -21,9 +25,9 @@ export const TrackedComponent = React.createClass({
     timer.on('active', function() {
         self.idleTimeInMs += Date.now()-self.startIdleTimer;
     });
-  },
+  }
 
-  componentWillUnmount: function(){
+  componentWillUnmount(){
      if(!this.componentWillMountTimestamp){
        throw "ComponentWillMountTimestamp was not initialized. Check if super.componentWillMount() was called"
      }
@@ -36,4 +40,4 @@ export const TrackedComponent = React.createClass({
         {'Component Name' : this.constructor.displayName});
      
   }
-});
+}


### PR DESCRIPTION
Changed from 
`React.createClass`
to 
`extends Component`
in order to remove the deprecation warning when using the lib.