### PR TITLE
Make history optional in react-appinsights.d.ts

### DIFF
--- a/react-appinsights.d.ts
+++ b/react-appinsights.d.ts
@@ -9,7 +9,7 @@ declare module "react-appinsights" {
     interface ReactAppInsights {
         init(
             appInsightsOptions: Microsoft.ApplicationInsights.IConfig,
-            history: History
+            history?: History
         ): void;
 
         ai(): Microsoft.ApplicationInsights.IAppInsights;


### PR DESCRIPTION
History is an optional argument in the source code but was required in the d.ts.