### PR TITLE
add test for initialization without instrumentation key

### DIFF
--- a/test/ReactAI.test.ts
+++ b/test/ReactAI.test.ts
@@ -1,21 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import ReactAI from "../src/ReactAI";
 
 describe("ReactAI", () => {
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("fails initialization without instrumentation key", () => {
+    const ReactAI = require('../src/ReactAI').default;
+    expect(() => ReactAI.initialize({ instrumentationKey: "" })).toThrow();
+    expect(() => ReactAI.initialize({})).toThrow();
+  });
+
   it("initializes correctly", () => {
+    const ReactAI = require('../src/ReactAI').default;
     ReactAI.initialize({ instrumentationKey: "my-i-key" });
     expect(ReactAI.rootInstance).not.toBe(undefined);
     expect(ReactAI.rootInstance.config.instrumentationKey).toBe("my-i-key");
   });
 
   it("sets debug mode as expected", () => {
+    const ReactAI = require('../src/ReactAI').default;
     ReactAI.initialize({ instrumentationKey: "my-i-key", debug: true });
     expect(ReactAI.isDebugMode).toBe(true);
   });
 
   it("sets context correctly", () => {
+    const ReactAI = require('../src/ReactAI').default;
     ReactAI.initialize({ instrumentationKey: "my-i-key" });
     ReactAI.setContext({ prop1: "value1", prop2: "value2" });
     expect(ReactAI.context.prop1).toBe("value1");
@@ -23,6 +36,7 @@ describe("ReactAI", () => {
   });
 
   it("resets context correctly", () => {
+    const ReactAI = require('../src/ReactAI').default;
     ReactAI.initialize({ instrumentationKey: "my-i-key" });
     ReactAI.setContext({ prop3: "value3" }, true);
     expect(ReactAI.context.prop3).toBe("value3");
@@ -30,6 +44,7 @@ describe("ReactAI", () => {
   });
 
   it("resets context on initialization", () => {
+    const ReactAI = require('../src/ReactAI').default;
     ReactAI.initialize({ instrumentationKey: "my-i-key", initialContext: { prop1: "value1" } });
     expect(ReactAI.context.prop1).toBe("value1");
     expect(ReactAI.context.prop2).toBe(undefined);


### PR DESCRIPTION
- adds simple testing for initialization without instrumentation key
- adds [Jest's reset](https://jestjs.io/docs/en/jest-object#jestresetmodules) module before each test - related Jest issue: https://github.com/facebook/jest/issues/3236 

Related issue: #35 