### PR TITLE
Update react-appinsights to application insights next version, update test, add ReactAIContainer to provide default container available to ReactAITracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,27 @@ To initialize Application Insights add the following to the entry point
 file of your application (e.g. index.js):
 
 ```javascript
-import { ReactAI } from "react-appinsights";
-ReactAI.initialize({ instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx" });
+import { ReactAIContainer } from "react-appinsights";
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+
+let myReactAI = new ReactAI();
+let appInsights = new ApplicationInsights({
+  config: {
+    instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+    extensions: [myReactAI],
+    extensionConfig: {
+      "ApplicationInsightsReactUsage": { debug: false }
+    }
+  }
+});
+
+ReactAIContainer.defaultReactAIContainer = new ReactAIContainer(appInsights, reactAI);
 ```
 
 See [this Application Insights tutorial for Node.js][appinsights-nodejs]
 for more details on how to obtain the instrumentation key.
 
-In addition to `instrumentationKey`, `IReactAISettings` has following non-mandatory configuration options:
+`IReactAISettings` has following non-mandatory configuration options to be passed into the extensionConfig object:
 
 ```typescript
 interface IReactAISettings {
@@ -51,7 +64,11 @@ import { Router } from "react-router-dom";
 import { createBrowserHistory } from "history";
 
 const history = createBrowserHistory();
-ReactAI.init({ instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx", history: history });
+
+In the code sample above, set configuration as follows:
+    extensionConfig: {
+      "ApplicationInsightsReactUsage": { debug: false, history: history }
+    }
 
 ReactDOM.render(
   <Router history={history}>
@@ -63,7 +80,7 @@ ReactDOM.render(
 
 #### Enable React components usage tracking
 
-To enable React components usage tracking, apply the `withAITracking` higher-order
+To instrument various React components usage tracking, apply the `withAITracking` higher-order
 component function.
 
 ```javascript
@@ -102,7 +119,7 @@ Please note that it can take up to 10 minutes for new custom metric to appear in
 To augment all telemetry with additional properties use `setContext` method. For instance:
 
 ```javascript
-ReactAI.setContext({ CorrelationId: "some-unique-correlation-id", Referrer: document.referrer });
+myReactAI.setContext({ CorrelationId: "some-unique-correlation-id", Referrer: document.referrer });
 ```
 
 This will add CorrelationId and Referrer property to all page views, ajax calls, exceptions and other telemetry sent to Application Insights.
@@ -114,7 +131,7 @@ This will add CorrelationId and Referrer property to all page views, ajax calls,
 Use the following method to get the original AppInsights object:
 
 ```javascript
-var appInsights = ReactAI.rootInstance;
+var appInsights = ReactAIContainer.applicationInsights;
 ```
 
 Refer to [this doc][appinsights-js-api] for information on the Javascript API of Application Insights.
@@ -127,11 +144,14 @@ Essentially, `instrumentationKey` is the only mandatory configuration option but
 
 ```javascript
 ReactAI.initialize({
-  // ReactAI config
-  instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
-  debug: true,
-  history: history,
+  extensionConfig: {
+    "ApplicationInsightsReactUsage": {
+      {
+        debug: true,
+        history: history
+      },
   // AI specific config
+  instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
   disableCorrelationHeaders: false,
   disableFetchTracking: false,
   enableCorsCorrelation: true,

--- a/README.md
+++ b/README.md
@@ -23,20 +23,21 @@ To initialize Application Insights add the following to the entry point
 file of your application (e.g. index.js):
 
 ```javascript
-import { ReactAIContainer } from "react-appinsights";
+import { ReactAIContainer, ReactAI } from "react-appinsights";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 
 let myReactAI = new ReactAI();
 let appInsights = new ApplicationInsights({
   config: {
     instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
-    extensions: [myReactAI],
+    extensions: [myReactAI.extensionIdentifier],
     extensionConfig: {
-      "ApplicationInsightsReactUsage": { debug: false }
+      [ReactAI.extensionIdentifier]: { debug: false }
     }
   }
 });
 
+appInsights.loadAppInsights();
 ReactAIContainer.defaultReactAIContainer = new ReactAIContainer(appInsights, reactAI);
 ```
 
@@ -67,7 +68,7 @@ const history = createBrowserHistory();
 
 In the code sample above, set configuration as follows:
     extensionConfig: {
-      "ApplicationInsightsReactUsage": { debug: false, history: history }
+      [ReactAI.extensionIdentifier]: { debug: false, history: history }
     }
 
 ReactDOM.render(
@@ -145,7 +146,7 @@ Essentially, `instrumentationKey` is the only mandatory configuration option but
 ```javascript
 ReactAI.initialize({
   extensionConfig: {
-    "ApplicationInsightsReactUsage": {
+    [ReactAI.extensionIdentifier]: {
       {
         debug: true,
         history: history

--- a/package-lock.json
+++ b/package-lock.json
@@ -2157,8 +2157,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2179,14 +2178,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2201,20 +2198,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2331,8 +2325,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2344,7 +2337,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2359,7 +2351,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2367,14 +2358,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2393,7 +2382,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2474,8 +2462,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2487,7 +2474,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2573,8 +2559,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2610,7 +2595,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2630,7 +2614,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2674,14 +2657,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3682,6 +3663,12 @@
         "jest-mock": "^24.0.0",
         "jest-util": "^24.0.0"
       }
+    },
+    "jest-environment-node-debug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node-debug/-/jest-environment-node-debug-2.0.0.tgz",
+      "integrity": "sha1-XvCYlC/sG2r17khB9Pii/0GVYvk=",
+      "dev": true
     },
     "jest-get-type": {
       "version": "24.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "jest": "^24.1.0",
+    "jest-environment-node-debug": "^2.0.0",
     "jest-junit-reporter": "^1.1.0",
     "prettier": "^1.16.4",
     "react-dom": "^16.8.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist-esm/src/index.d.ts",
   "scripts": {
     "clean": "rimraf dist dist-*",
-    "build": "tsc -v && tsc -p . && rollup -c && rollup -c rollup.test.config.js",
+    "build": "tsc -p . && rollup -c && rollup -c rollup.test.config.js",
     "test": "jest --config jestconfig.json",
     "test-watch": "jest --config jestconfig.json --watch",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist-esm/src/index.d.ts",
   "scripts": {
     "clean": "rimraf dist dist-*",
-    "build": "tsc -p . && rollup -c && rollup -c rollup.test.config.js",
+    "build": "tsc -v && tsc -p . && rollup -c && rollup -c rollup.test.config.js",
     "test": "jest --config jestconfig.json",
     "test-watch": "jest --config jestconfig.json --watch",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",

--- a/src/ReactAI.ts
+++ b/src/ReactAI.ts
@@ -16,7 +16,7 @@ export default class ReactAI implements ITelemetryPlugin {
   public static extensionIdentifier = "ApplicationInsightsReactUsage";
   processTelemetry: (env: ITelemetryItem) => void;
   public identifier = ReactAI.extensionIdentifier;
-  priority: number = 300;
+  priority: number = 201;
   private _nextPlugin!: ITelemetryPlugin;
   private _initialized = false;
   private debug: boolean | undefined;

--- a/src/ReactAI.ts
+++ b/src/ReactAI.ts
@@ -3,7 +3,7 @@
 
 import { IPlugin } from '@microsoft/applicationinsights-core-js';
 import { IAppInsightsCore, IApplicationInsights, IConfig, IConfiguration, IPageViewTelemetry, ITelemetryItem, ITelemetryPlugin } from "@microsoft/applicationinsights-web";
-import { Action, Location } from "history";
+import { Action, History, Location } from "history";
 import IReactAISettings from './IReactAISettings';
 
 /**

--- a/src/ReactAIContainer.ts
+++ b/src/ReactAIContainer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { ApplicationInsights, ITelemetryPlugin } from '@microsoft/applicationinsights-web';
 import { ReactAI } from ".";
 
 /**
@@ -16,13 +16,27 @@ export default class ReactAIContainer {
     private _reactAI: ReactAI;
     public constructor(appInsights: ApplicationInsights, reactAI: ReactAI) {
         if (appInsights === undefined || appInsights === null) {
-            throw new Error("Invalid input");
+            throw new Error("Invalid input for application insights");
         }
         this.ai = appInsights;
 
         this._reactAI = reactAI;
         if (this._reactAI === undefined || this._reactAI === null) {
-            throw new Error("No extension found for ReactAI");
+            throw new Error("Invalid input for ReactAI");
+        }
+
+        let found = false;
+        let exts = <ITelemetryPlugin[]>(<any>this.ai.core)._extensions;
+        exts = exts ? exts : [];
+        for (let i = 0; i < exts.length; i++) {
+            if (exts[i].identifier === ReactAI.extensionIdentifier) {
+                found = true;
+                break;
+            }
+        };
+
+        if (!found) {
+            throw new Error("Input ReactAI extension is not one of extensions in appInsights instance");
         }
     }
 

--- a/src/ReactAIContainer.ts
+++ b/src/ReactAIContainer.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { ReactAI } from ".";
+
+/**
+ * Module to include Microsoft Application Insights in React applications.
+ *
+ * @export
+ * @class ReactAIContainer
+ */
+export default class ReactAIContainer {
+
+    private ai!: ApplicationInsights;
+    private _reactAI: ReactAI;
+    public constructor(appInsights: ApplicationInsights, reactAI: ReactAI) {
+        if (appInsights === undefined || appInsights === null) {
+            throw new Error("Invalid input");
+        }
+        this.ai = appInsights;
+
+        this._reactAI = reactAI;
+        if (this._reactAI === undefined || this._reactAI === null) {
+            throw new Error("No extension found for ReactAI");
+        }
+    }
+
+    /**
+    * Returns the underlying root instance of Application Insights.
+    *
+    * @readonly
+    * @static
+    * @type {ApplicationInsights}
+    * @memberof ReactAI
+    */
+    public get reactAI(): ReactAI {
+        return this._reactAI;
+    }
+
+    public get applicationInsights(): ApplicationInsights {
+        return this.ai;
+    }
+
+    private static _defaultValue: ReactAIContainer;
+    public static get defaultReactAIContainer(): ReactAIContainer {
+        return ReactAIContainer._defaultValue;
+    }
+
+    public static set defaultReactAIContainer(container: ReactAIContainer) {
+        ReactAIContainer._defaultValue = container;
+    }
+}

--- a/src/ReactAIContainer.ts
+++ b/src/ReactAIContainer.ts
@@ -26,6 +26,7 @@ export default class ReactAIContainer {
         }
 
         let found = false;
+        // In version 2.0 of applicationinsights-web, any cast is not required as the property _extensions is public 
         let exts = <ITelemetryPlugin[]>(<any>this.ai.core)._extensions;
         exts = exts ? exts : [];
         for (let i = 0; i < exts.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@
 
 import IReactAISettings from "./IReactAISettings";
 import ReactAI from "./ReactAI";
+import ReactAIContainer from "./ReactAIContainer";
 import withAITracking from "./withAITracking";
 
-export { ReactAI, IReactAISettings, withAITracking };
+export { ReactAI, ReactAIContainer, IReactAISettings, withAITracking };
 

--- a/src/withAITracking.tsx
+++ b/src/withAITracking.tsx
@@ -10,6 +10,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
   if (componentName === undefined || componentName === null || typeof componentName !== 'string') {
     componentName = Component.prototype.constructor.name;
   }
+
   let container = ReactAIContainer.defaultReactAIContainer;
   let ai = container.applicationInsights;
   let reactAI = container.reactAI;

--- a/src/withAITracking.tsx
+++ b/src/withAITracking.tsx
@@ -3,13 +3,16 @@
 
 import { IMetricTelemetry } from "@microsoft/applicationinsights-web";
 import * as React from "react";
-import { ReactAI } from ".";
+import ReactAIContainer from "./ReactAIContainer";
 
 export default function withAITracking<P>(Component: React.ComponentType<P>, componentName?: string): React.ComponentClass<P> {
 
   if (componentName === undefined || componentName === null || typeof componentName !== 'string') {
     componentName = Component.prototype.constructor.name;
   }
+  let container = ReactAIContainer.defaultReactAIContainer;
+  let ai = container.applicationInsights;
+  let reactAI = container.reactAI;
 
   return class extends React.Component<P> {
     private mountTimestamp: number = 0;
@@ -43,7 +46,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
         throw new Error("withAITracking:componentWillUnmount: mountTimestamp isn't initialized.");
       }
 
-      if (!ReactAI.rootInstance) {
+      if (!container || !ai) {
         throw new Error("withAITracking:componentWillUnmount: ReactAI isn't initialized yet.");
       }
 
@@ -68,7 +71,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
         "componentWillUnmount",
         `Tracking ${engagementTime} seconds of engagement time for ${componentName}.`
       );
-      ReactAI.rootInstance.trackMetric(metricData, additionalProperties);
+      ai.trackMetric(metricData, additionalProperties);
     }
 
     public render() {
@@ -103,7 +106,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
     }
 
     private debugLog(from: string, message: string): void {
-      if (ReactAI.isDebugMode) {
+      if (reactAI.isDebugMode) {
         console.log(`withAITracking:${componentName}:${from}: ${message}`, {
           engagementTime: this.getEngagementTimeSeconds(),
           firstActiveTime: this.firstActiveTimestamp,

--- a/test/ReactAI.test.ts
+++ b/test/ReactAI.test.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import createHistory from "history/createBrowserHistory";
+import ReactAI from "../src/ReactAI";
 
 const IKEY: string = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx";
 
@@ -10,64 +12,110 @@ describe("ReactAI", () => {
     jest.resetModules();
   });
 
-  it("fails initialization without instrumentation key", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    expect(() => ReactAI.initialize({ instrumentationKey: "" })).toThrow();
-    expect(() => ReactAI.initialize({})).toThrow();
-  });
-
   it("initializes correctly", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    ReactAI.initialize({ instrumentationKey: IKEY });
-    expect(ReactAI.rootInstance).not.toBe(undefined);
-    expect(ReactAI.rootInstance.config.instrumentationKey).toBe(IKEY);
+    let reactAI = new ReactAI();
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": { debug: false }
+        }
+      }
+    });
+    expect(reactAI).not.toBe(undefined);
+    expect(appInsights).not.toBe(undefined);
   });
 
   it("sets debug mode as expected", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    ReactAI.initialize({ instrumentationKey: IKEY, debug: true });
-    expect(ReactAI.isDebugMode).toBe(true);
+
+    let reactAI = new ReactAI();
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": { debug: true }
+        }
+      }
+    });
+    expect(reactAI.isDebugMode).toBe(true);
   });
 
   it("sets context correctly", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    ReactAI.initialize({ instrumentationKey: IKEY });
-    ReactAI.setContext({ prop1: "value1", prop2: "value2" });
-    expect(ReactAI.context.prop1).toBe("value1");
-    expect(ReactAI.context.prop2).toBe("value2");
+    let reactAI = new ReactAI();
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": { debug: false }
+        }
+      }
+    });
+    reactAI.setContext({ prop1: "value1", prop2: "value2" });
+    expect(reactAI.context.prop1).toBe("value1");
+    expect(reactAI.context.prop2).toBe("value2");
   });
 
   it("resets context correctly", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    ReactAI.initialize({ instrumentationKey: IKEY });
-    ReactAI.setContext({ prop1: "value1" });
-    expect(ReactAI.context.prop1).toBe("value1");
-    ReactAI.setContext({ prop3: "value3" }, true);
-    expect(ReactAI.context.prop3).toBe("value3");
-    expect(ReactAI.context.prop1).toBe(undefined);
+    let reactAI = new ReactAI();
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": { debug: false }
+        }
+      }
+    });
+    reactAI.setContext({ prop1: "value1" });
+    expect(reactAI.context.prop1).toBe("value1");
+    reactAI.setContext({ prop3: "value3" }, true);
+    expect(reactAI.context.prop3).toBe("value3");
+    expect(reactAI.context.prop1).toBe(undefined);
   });
 
   it("resets context on initialization", () => {
-    const ReactAI = require("../src/ReactAI").default;
-    ReactAI.initialize({ instrumentationKey: IKEY, initialContext: { prop1: "value1" } });
-    expect(ReactAI.context.prop1).toBe("value1");
-    expect(ReactAI.context.prop2).toBe(undefined);
-    expect(ReactAI.context.prop3).toBe(undefined);
+    let reactAI = new ReactAI();
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": { debug: false, initialContext: { prop1: "value1" } }
+        }
+      }
+    });
+
+    expect(reactAI.context.prop1).toBe("value1");
+    expect(reactAI.context.prop2).toBe(undefined);
+    expect(reactAI.context.prop3).toBe(undefined);
   });
 
   it("tracks page views", () => {
-    const ReactAI = require("../src/ReactAI").default;
+
     const emulatedHistory = createHistory();
     const initialContext = { prop1: "value1" };
+    let reactAI = new ReactAI();
+    // Should call trackPageView upon initialization to track the view of the initial page
+    let appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey: IKEY,
+        extensions: [reactAI],
+        extensionConfig: {
+          "ApplicationInsightsReactUsage": {
+            debug: false, initialContext: initialContext, history: emulatedHistory
+          }
+        }
+      }
+    });
 
     // Mock the internal instance of AppInsights
-    ReactAI.ai = {};
-    ReactAI.rootInstance.trackPageView = jest.fn();
-    ReactAI.rootInstance.addTelemetryInitializer = jest.fn();
+    appInsights.trackPageView = jest.fn();
+    appInsights.addTelemetryInitializer = jest.fn();
     jest.useFakeTimers();
 
-    ReactAI.initialize({ instrumentationKey: IKEY, initialContext, debug: true, history: emulatedHistory });
-    // Should call trackPageView upon initialization to track the view of the initial page
 
     // Emulate navigation to different URL-addressed pages
     emulatedHistory.push("/home", { some: "state" });
@@ -77,9 +125,9 @@ describe("ReactAI", () => {
     const pageViewTelemetry1 = { uri: "/", properties: initialContext };
     const pageViewTelemetry2 = { uri: "/home", properties: initialContext };
     const pageViewTelemetry3 = { uri: "/new-fancy-page", properties: initialContext };
-    expect(ReactAI.rootInstance.trackPageView).toHaveBeenCalledTimes(3);
-    expect(ReactAI.rootInstance.trackPageView).toHaveBeenNthCalledWith(1, pageViewTelemetry1);
-    expect(ReactAI.rootInstance.trackPageView).toHaveBeenNthCalledWith(2, pageViewTelemetry2);
-    expect(ReactAI.rootInstance.trackPageView).toHaveBeenNthCalledWith(3, pageViewTelemetry3);
+    expect(appInsights.trackPageView).toHaveBeenCalledTimes(3);
+    expect(appInsights.trackPageView).toHaveBeenNthCalledWith(1, pageViewTelemetry1);
+    expect(appInsights.trackPageView).toHaveBeenNthCalledWith(2, pageViewTelemetry2);
+    expect(appInsights.trackPageView).toHaveBeenNthCalledWith(3, pageViewTelemetry3);
   });
 });

--- a/test/withAITracking.test.tsx
+++ b/test/withAITracking.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { IMetricTelemetry } from "@microsoft/applicationinsights-web";
+import { ApplicationInsights, IMetricTelemetry } from "@microsoft/applicationinsights-web";
 import * as Enzyme from "enzyme";
 import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
-import { ReactAI, withAITracking } from "../src";
+import { ReactAI, ReactAIContainer, withAITracking } from "../src";
 import { TestComponent } from "./TestComponent";
 
 Enzyme.configure({ adapter: new Adapter.default() });
@@ -32,8 +32,19 @@ describe("<TestComponentWithTracking /> i.e. withAITracking(TestComponent)", () 
     let trackMetricSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      ReactAI.initialize({ instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx", debug: false });
-      trackMetricSpy = jest.spyOn(ReactAI.rootInstance, "trackMetric");
+      let reactAI = new ReactAI();
+      let appInsights = new ApplicationInsights({
+        config: {
+          instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
+          extensions: [reactAI],
+          extensionConfig: {
+            "ApplicationInsightsReactUsage": { debug: false }
+          }
+        }
+      });
+
+      ReactAIContainer.defaultReactAIContainer = new ReactAIContainer(appInsights, reactAI);
+      trackMetricSpy = jest.spyOn(appInsights, "trackMetric");
       trackMetricSpy.mockReset();
     });
 


### PR DESCRIPTION
> Update react-appinsights to application insights next version, update test, add ReactAIContainer to provide default container available to ReactAITracking

> Usage looks like the following:
let reactAI = new ReactAI();
    let appInsights = new ApplicationInsights({
      config: {
        instrumentationKey: IKEY,
        extensions: [reactAI],
        extensionConfig: {
          "ApplicationInsightsReactUsage": { debug: false }
        }
      }
    });
   ReactAIContainer.defaultReactAIContainer = new ReactAIContainer(appInsights, reactAI);




