### PR TITLE
ReactAI as singleton instance upon import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ To initialize Application Insights, add the following to the entry point
 file of your application (e.g. `index.js`):
 
 ```javascript
-import { ReactAI } from "react-appinsights";
+import { reactAI } from "react-appinsights";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 
-let reactAI = new ReactAI();
 let appInsights = new ApplicationInsights({
   config: {
     instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
     extensions: [reactAI],
     extensionConfig: {
-      [ReactAI.extensionId]: { debug: false }
+      [reactAI.extensionId]: { debug: false }
     }
   }
 });
@@ -58,7 +57,8 @@ To track page views, pass a history object to the init method.
 For more information see the [documentation][react-router] of the `react-router` package.
 
 ```javascript
-import ReactAI from "react-appinsights";
+import { reactAI } from "react-appinsights";
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import { Router } from "react-router-dom";
 import { createBrowserHistory } from "history";
 
@@ -132,7 +132,7 @@ This will add CorrelationId and Referrer property to all page views, ajax calls,
 Use the following method to get the original AppInsights object:
 
 ```javascript
-var appInsights = ReactAI.appInsights;
+var appInsights = reactAI.appInsights;
 ```
 
 Refer to [this doc][appinsights-js-api] for information on the Javascript API of Application Insights.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import IReactAISettings from "./IReactAISettings";
-import ReactAI from "./ReactAI";
+import { reactAI } from "./ReactAI";
 import withAITracking from "./withAITracking";
 
-export { ReactAI, IReactAISettings, withAITracking };
+export { reactAI, IReactAISettings, withAITracking };
 

--- a/src/withAITracking.tsx
+++ b/src/withAITracking.tsx
@@ -3,7 +3,7 @@
 
 import { IMetricTelemetry } from "@microsoft/applicationinsights-web";
 import * as React from "react";
-import ReactAI from "./ReactAI";
+import { reactAI } from "./ReactAI";
 
 /**
  * Higher-order component function to hook Application Insights tracking 
@@ -50,7 +50,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
         throw new Error("withAITracking:componentWillUnmount: mountTimestamp isn't initialized.");
       }
 
-      if (!ReactAI.appInsights) {
+      if (!reactAI.appInsights) {
         throw new Error("withAITracking:componentWillUnmount: ReactAI isn't initialized.");
       }
 
@@ -75,7 +75,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
         "componentWillUnmount",
         `Tracking ${engagementTime} seconds of engagement time for ${componentName}.`
       );
-      ReactAI.appInsights.trackMetric(metricData, additionalProperties);
+      reactAI.appInsights.trackMetric(metricData, additionalProperties);
     }
 
     public render() {
@@ -110,7 +110,7 @@ export default function withAITracking<P>(Component: React.ComponentType<P>, com
     }
 
     private debugLog(from: string, message: string): void {
-      if (ReactAI.isDebugMode) {
+      if (reactAI.isDebugMode) {
         console.log(`withAITracking:${componentName}:${from}: ${message}`, {
           engagementTime: this.getEngagementTimeSeconds(),
           firstActiveTime: this.firstActiveTimestamp,

--- a/test/ReactAI.test.ts
+++ b/test/ReactAI.test.ts
@@ -3,23 +3,20 @@
 
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import createHistory from "history/createBrowserHistory";
-import { IReactAISettings } from '../src';
-import ReactAI from "../src/ReactAI";
+import { IReactAISettings, reactAI } from '../src';
 
 const IKEY: string = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx";
 
-let reactAI: ReactAI;
 let appInsights: ApplicationInsights;
 
 describe("ReactAI", () => {
 
   function init(reactAIconfig: IReactAISettings) {
-    reactAI = new ReactAI();
     reactAI._trackInitialPageViewInternal = jest.fn();
     appInsights = new ApplicationInsights({
       config: {
         extensionConfig: {
-          [ReactAI.extensionId]: reactAIconfig
+          [reactAI.extensionId]: reactAIconfig
         },
         extensions: [reactAI],
         instrumentationKey: IKEY
@@ -32,12 +29,12 @@ describe("ReactAI", () => {
     init({});
     expect(reactAI).not.toBe(undefined);
     expect(appInsights).not.toBe(undefined);
-    expect(ReactAI.isDebugMode).toBe(false);
+    expect(reactAI.isDebugMode).toBe(false);
   });
 
   it("sets debug mode as expected", () => {
     init({ debug: true });
-    expect(ReactAI.isDebugMode).toBe(true);
+    expect(reactAI.isDebugMode).toBe(true);
   });
 
   it("sets context correctly", () => {
@@ -70,8 +67,8 @@ describe("ReactAI", () => {
     init({ debug: false, initialContext, history: emulatedHistory });
 
     // Mock the internal instance of AppInsights
-    ReactAI.appInsights.trackPageView = jest.fn();
-    ReactAI.appInsights.addTelemetryInitializer = jest.fn();
+    reactAI.appInsights.trackPageView = jest.fn();
+    reactAI.appInsights.addTelemetryInitializer = jest.fn();
 
     const pageViewTelemetry1 = { uri: "/", properties: initialContext };
     expect(reactAI._trackInitialPageViewInternal).toHaveBeenCalledTimes(1);
@@ -84,8 +81,8 @@ describe("ReactAI", () => {
 
     const pageViewTelemetry2 = { uri: "/home", properties: initialContext };
     const pageViewTelemetry3 = { uri: "/new-fancy-page", properties: initialContext };
-    expect(ReactAI.appInsights.trackPageView).toHaveBeenCalledTimes(2);
-    expect(ReactAI.appInsights.trackPageView).toHaveBeenNthCalledWith(1, pageViewTelemetry2);
-    expect(ReactAI.appInsights.trackPageView).toHaveBeenNthCalledWith(2, pageViewTelemetry3);
+    expect(reactAI.appInsights.trackPageView).toHaveBeenCalledTimes(2);
+    expect(reactAI.appInsights.trackPageView).toHaveBeenNthCalledWith(1, pageViewTelemetry2);
+    expect(reactAI.appInsights.trackPageView).toHaveBeenNthCalledWith(2, pageViewTelemetry3);
   });
 });

--- a/test/withAITracking.test.tsx
+++ b/test/withAITracking.test.tsx
@@ -5,14 +5,13 @@ import { ApplicationInsights, IMetricTelemetry } from "@microsoft/applicationins
 import * as Enzyme from "enzyme";
 import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
-import { ReactAI, withAITracking } from "../src";
+import { reactAI, withAITracking } from "../src";
 import { TestComponent } from "./TestComponent";
 
 const IKEY: string = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx";
 Enzyme.configure({ adapter: new Adapter.default() });
 
 let trackMetricSpy: jest.SpyInstance;
-let reactAI: ReactAI;
 let appInsights: ApplicationInsights;
 
 describe("withAITracking(TestComponent)", () => {
@@ -20,18 +19,17 @@ describe("withAITracking(TestComponent)", () => {
   const trackedTestComponentWrapper = () => Enzyme.shallow(<TestComponentWithTracking />);
 
   beforeEach(() => {
-    reactAI = new ReactAI();
     appInsights = new ApplicationInsights({
       config: {
         extensionConfig: {
-          [ReactAI.extensionId]: { debug: false }
+          [reactAI.extensionId]: { debug: false }
         },
         extensions: [reactAI],
         instrumentationKey: IKEY
       }
     });
     appInsights.loadAppInsights();
-    trackMetricSpy = jest.spyOn(ReactAI.appInsights, "trackMetric");
+    trackMetricSpy = jest.spyOn(reactAI.appInsights, "trackMetric");
   });
 
   it("should wrap <TestComponent />", () => {


### PR DESCRIPTION
Since there's only one instance of ReactAI, we might as well initialize it behind the scenes and let the user import it as a singleton instance.  

It [appears ](https://stackoverflow.com/a/50063973)that using 
```typescript
export const reactAI = new ReactAI();
```
would guarantee the existence of only one instance without using the usual getInstance/private constructor boilerplate. The user would then import anywhere the same instance as: 
```typescript
import { reactAI } from "react-appinsights";
```

Besides, all static attributes have been changed to non-static.

(this PR also removes the initialized flag... not sure if there's any case in which anyone would call twice the constructor or AppInsights and so twice the initialize function as well..)